### PR TITLE
Add new route for downloading samples

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from flask import (
     session,
     url_for,
     jsonify,
-    flash,
+    flash, send_file,
 )
 from flask_login import (
     LoginManager,
@@ -253,6 +253,12 @@ def delete_sample(sample_id):
     if not current_user.is_admin:
         return jsonify({"message": "Access denied"}), 403
     return samples.delete_sample(sample_id)
+
+@app.route("/sample/<int:sample_id>/download/")
+def download_sample(sample_id):
+    sample = Sample.query.get_or_404(sample_id)
+    file_path = os.path.join("static/media/samps", sample.stored_as)
+    return send_file(file_path, as_attachment=True, download_name=sample.filename)
 
 @app.route("/user/<int:user_id>/")
 def user_page(user_id):

--- a/templates/sample.html
+++ b/templates/sample.html
@@ -20,8 +20,7 @@
         </div>
         <div class="sample-info-box">
             <div class="sample-buttons">
-                <a href="{{ url_for('static', filename='media/samps/' + sample.filename) }}"
-                   download="{{ sample.filename }}"
+                <a href="{{ url_for('download_sample', sample_id=sample.id) }}"
                    class="sample-page-button" style="--hue: 100">
                     <span>Download sample</span>
                 </a>

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import os
 
+import dotenv
 import ffmpeg
 import shutil
 from sqlalchemy import create_engine, text
@@ -116,5 +117,6 @@ def err_sanitize(err):
             strerr = strerr.replace(part, "<stripped>")
     return strerr
 
+dotenv.load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 engine = create_engine(DATABASE_URL)


### PR DESCRIPTION
The old way stopped working when we started separating the displayed filename and the stored filename.