### PR TITLE
switch to tomllib

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
-import rtoml as toml
+import tomllib
 
-settings = toml.load(open("config.toml"))
+with open("config.toml", "rc") as f:
+    settings = tomllib.load(f)
 
 USER_APPROVAL = settings["user_approval"]
 VERSION = settings["version"]

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
-import toml
+import rtoml as toml
 
-settings = toml.load("config.toml")
+settings = toml.load(open("config.toml"))
 
 USER_APPROVAL = settings["user_approval"]
 VERSION = settings["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ psycopg2-binary==2.9.10
 gunicorn
 Markdown~=3.8
 filetype_py~=1.0
-toml~=0.10.2


### PR DESCRIPTION
Python has a built in toml library as of 3.11, it gets more of the toml spec correctly and also the one i was using hasn't been updated in 2 years (probably because of tomllib)