### PR TITLE
Add samples to database on upload rather than on edit

### DIFF
--- a/blueprints/main_routes.py
+++ b/blueprints/main_routes.py
@@ -99,8 +99,12 @@ def edit_sample(sample_id):
     stored_as = session.get(f"stored_as_{sample_id}")
     force_reencode = session.get(f"force_reencode")
 
-    if not uploaded_sample_id or uploaded_sample_id != sample_id:
-        flash("Invalid request.", "error")
+    if not uploaded_sample_id:
+        flash("Sample ID empty.", "error")
+        return redirect(url_for("main.upload"))
+
+    if uploaded_sample_id != sample_id:
+        flash("Sample ID doesn't match.", "error")
         return redirect(url_for("main.upload"))
 
     if request.method == "POST":
@@ -161,8 +165,12 @@ def batch_edit_samples(sample_ids):
         if not force_reencode:
             force_reencode = session.get(f"force_reencode")
 
-        if not uploaded_sample_id or uploaded_sample_id != sample_id:
-            flash("Invalid request.", "error")
+        if not uploaded_sample_id:
+            flash("Sample ID empty.", "error")
+            return redirect(url_for("main.upload"))
+
+        if uploaded_sample_id != sample_id:
+            flash("Sample ID doesn't match.", "error")
             return redirect(url_for("main.upload"))
 
         sample_data.append(

--- a/blueprints/main_routes.py
+++ b/blueprints/main_routes.py
@@ -137,7 +137,7 @@ def edit_sample(sample_id):
             flash("Failed to upload sample. Please reencode or try another video.", "error")
             return redirect(url_for("main.upload"))
 
-        return redirect(url_for("main.home_page"))
+        return redirect(url_for("main.sample_page", sample_id=sample_id))
 
     return render_template(
         "edit_sample.html",
@@ -208,7 +208,7 @@ def batch_edit_samples(sample_ids):
                 flash("Failed to upload one or more sample(s). Please reencode or try another video.", "error")
                 return redirect(url_for("main.upload"))
 
-        return redirect(url_for("main.home_page"))
+        return redirect(url_for("main.user_page", user_id=current_user.id))
 
     return render_template(
         "batch_edit_samples.html",

--- a/blueprints/main_routes.py
+++ b/blueprints/main_routes.py
@@ -293,10 +293,19 @@ def user_page(user_id):
         is_admin=current_user.is_authenticated and current_user.is_admin
     )
 
+    samples = []
+    private_samples = []
+    for sample in res_samples:
+        if not sample.is_public:
+            private_samples.append(sample)
+        else:
+            samples.append(sample)
+
     return render_template(
         "user.html",
         title=f"{user.username} - YTPMV Sample Database",
-        samples=res_samples,
+        samples=samples,
+        samples_under_review=private_samples,
         user=user,
     )
 

--- a/blueprints/main_routes.py
+++ b/blueprints/main_routes.py
@@ -89,7 +89,7 @@ def sample_page(sample_id):
 @main_bp.route("/sample/edit/<sample_id>/", methods=["GET", "POST"])
 @login_required
 def edit_sample(sample_id):
-    uploaded_sample_id = session.get(f"uploaded_sample_id_{sample_id}")
+    uploaded_sample_id = str(session.get(f"uploaded_sample_id_{sample_id}"))
     old_filename = session.get(f"filename_{sample_id}")
     thumbnail = session.get(f"thumbnail_{sample_id}")
     stored_as = session.get(f"stored_as_{sample_id}")
@@ -112,10 +112,8 @@ def edit_sample(sample_id):
             source_id = None
 
         edit_status = samples.edit_sample(
+            sample_id,
             filename,
-            stored_as,
-            str(thumbnail),
-            current_user.id,
             source_id,
             tags,
             reencode
@@ -152,7 +150,7 @@ def batch_edit_samples(sample_ids):
     force_reencode = False
 
     for sample_id in sample_ids_list:
-        uploaded_sample_id = session.get(f"uploaded_sample_id_{sample_id}")
+        uploaded_sample_id = str(session.get(f"uploaded_sample_id_{sample_id}"))
         filename = session.get(f"filename_{sample_id}")
         thumbnail = session.get(f"thumbnail_{sample_id}")
         stored_as = session.get(f"stored_as_{sample_id}")
@@ -184,11 +182,9 @@ def batch_edit_samples(sample_ids):
 
         for sample_item in sample_data:
             filename = sample_item["filename"]
-            stored_as = sample_item["stored_as"]
-            thumbnail = sample_item["thumbnail"]
             sample_id = sample_item["sample_id"]
 
-            edit_status = samples.edit_sample(filename, stored_as, thumbnail, current_user.id, source_id, [], reencode)
+            edit_status = samples.edit_sample(sample_id, filename, source_id, [], reencode)
 
             session.pop(f"uploaded_sample_id_{sample_id}", None)
             session.pop(f"filename_{sample_id}", None)

--- a/models.py
+++ b/models.py
@@ -38,6 +38,7 @@ class Sample(db.Model):
     thumbnail_filename = db.Column(db.String, nullable=False)
     uploader = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     source_id = db.Column(db.Integer, db.ForeignKey("source.id"), nullable=True)
+    is_public = db.Column(db.Boolean, default=False, nullable=False)
 
     source = db.relationship("Source", back_populates="samples")
     likes = db.relationship("User", secondary=likes_table, backref="liked_samples")

--- a/samples.py
+++ b/samples.py
@@ -30,6 +30,7 @@ def edit_sample(sample_id, filename, source_id, tags, reencode):
     sample.filename = filename
     sample.source_id = source_id
 
+    sample.tags = [] # clear tags in the case of re-edits
     for sample_tag in tags:
         tag = Tag.query.filter_by(name=sample_tag).first()
         if tag is None:

--- a/samples.py
+++ b/samples.py
@@ -1,17 +1,16 @@
 import datetime
 import os
 import re
-import uuid
 import pathlib
 import secrets
 import file_type
 
 from flask import jsonify
-from sqlalchemy.exc import IntegrityError
+from flask_login import current_user
 
 from config import MB_UPLOAD_LIMIT
 from models import Metadata, Sample, db, Tag
-from utils import add_sample_to_db, check_video, create_thumbnail, reencode_video, add_tag_to_db
+from utils import add_sample_to_db, check_video, create_thumbnail, reencode_video, add_tag_to_db, update_metadata
 
 from werkzeug.utils import secure_filename
 
@@ -19,26 +18,18 @@ ALLOWED_UPLOAD_EXTENSIONS=["mp4"]
 ALLOWED_UPLOAD_EXTENSIONS_WITH_REENCODE=["m4v"]
 
 
-def edit_sample(filename, stored_as, thumbnail, uploader, source_id, tags, reencode):
-    if reencode:
-        reencode_video(stored_as)
-
-    try:
-        add_sample_to_db(
-            filename,
-            stored_as,
-            datetime.datetime.now(datetime.UTC),
-            str(thumbnail),
-            uploader,
-            source_id,
-        )
-    except Exception as e:
-        print(e)
+def edit_sample(sample_id, filename, source_id, tags, reencode):
+    sample = Sample.query.get(sample_id)
+    if not sample:
         return 1
 
-    sample = Sample.query.filter_by(stored_as=stored_as).first()
+    if reencode:
+        reencode_video(sample.stored_as)
+        update_metadata(sample.id)
 
-    print(tags)
+    sample.filename = filename
+    sample.source_id = source_id
+
     for sample_tag in tags:
         tag = Tag.query.filter_by(name=sample_tag).first()
         if tag is None:
@@ -46,11 +37,15 @@ def edit_sample(filename, stored_as, thumbnail, uploader, source_id, tags, reenc
                 continue
             add_tag_to_db(sample_tag, 5)
             tag = Tag.query.filter_by(name=sample_tag).first()
-        sample.tags.append(tag)
-        try:
-            db.session.commit()
-        except IntegrityError:
-            db.session.rollback()
+        if tag not in sample.tags:
+            sample.tags.append(tag)
+    
+    try:
+        db.session.commit()
+    except Exception as e:
+        print(e)
+        db.session.rollback()
+        return 1
 
     return 0
 
@@ -104,9 +99,31 @@ def upload(file):
             os.remove(upload_path)
             raise Exception("One or more of your sample(s) exceeded the file limit. Max supported filesize is 10MB per file.")
 
-        create_thumbnail(upload_path, f"static/media/thumbs/{timestamp}.png")
+        thumbnail_filename = f"{timestamp}.png"
+        create_thumbnail(upload_path, f"static/media/thumbs/{thumbnail_filename}")
 
-        sample_id = str(uuid.uuid4())
+        is_public = current_user.is_uploader
+        
+        try:
+            sample_id = add_sample_to_db(
+                original_filename,
+                stored_as,
+                datetime.datetime.now(datetime.UTC),
+                thumbnail_filename,
+                current_user.id,
+                None,
+                is_public
+            )
+            update_metadata(sample_id)
+        except Exception as e:
+            print(e)
+            if os.path.exists(upload_path):
+                os.remove(upload_path)
+            thumb_path = f"static/media/thumbs/{thumbnail_filename}"
+            if os.path.exists(thumb_path):
+                os.remove(thumb_path)
+            raise Exception(f"Failed to add sample to database: {e}")
+
     else:
         raise Exception("No file")
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -123,6 +123,17 @@ p {
 
 }
 
+.privacy-warning {
+    color: red;
+    background: #fee;
+    padding: 10px;
+    border: 1px solid red;
+    border-radius: 5px;
+    max-width: 900px;
+    width: calc(100% - 100px);
+    margin: 0 auto;
+}
+
 .sample-page-layout {
     display: grid;
     grid-template-columns: 1fr minmax(0, 900px) 1fr;
@@ -134,7 +145,6 @@ p {
     background-color: hsl(var(--hue), 85%, 75%);
     border-radius: 20px;
     max-width: 900px;
-    width: calc(100% - 100px);
     text-align: left;
     padding: 15px;
     display: grid;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -178,12 +178,12 @@ p {
     display: flex;
     gap: 10px;
     margin-bottom: 10px;
+    flex-wrap: wrap;
 }
 
 .sample-page-button {
-    flex: 1;
+    flex: 0 0 calc(50% - 27px);
     display: flex;
-    width: 100%;
     height: 50px;
     background-color: hsl(var(--hue), 60%, 65%);
     border: dimgrey solid 1px;

--- a/static/js/source_selector.js
+++ b/static/js/source_selector.js
@@ -12,6 +12,11 @@ function initSourceSelector() {
     const isHiddenByDefault = window.getComputedStyle(clearButton).display === 'none';
 
     function sourceBoxFill() {
+        if (sourceInput.disabled) {
+            sourceList.innerHTML = "";
+            return;
+        }
+
         const query = sourceInput.value;
 
         if (query.length < 1) {

--- a/templates/edit_sample.html
+++ b/templates/edit_sample.html
@@ -39,10 +39,10 @@
                         <b>Source:</b>
                     </td>
                     <td align="left">
-                        <input type="text" id="source" name="source" autocomplete="off" placeholder="">
+                        <input type="text" id="source" name="source" autocomplete="off" placeholder="" value="{{ source_name }}" {% if source_name %}disabled="disabled"{% endif %}>
                     </td>
                     <td>
-                        <button type="button" id="clear-source" disabled="disabled">Clear</button>
+                        <button type="button" id="clear-source" {% if not source_name %}disabled="disabled"{% endif %}>Clear</button>
                     </td>
                 </tr>
                 <tr>
@@ -56,17 +56,18 @@
                             <ul id="source-suggestions">
                             </ul>
                         </span>
-                        <input type="hidden" id="source_id" name="source_id">
+                        <input type="hidden" id="source_id" name="source_id" value="{{ source_id if source_id else "" }}">
                     </td>
                 </tr>
             </table>
 
             <div>
                 <label for="tags"><b>Tags:</b></label>
-                <br><textarea id="tags" name="tags" rows="4" cols="45" maxlength="200"></textarea>
+                <br><textarea id="tags" name="tags" rows="4" cols="45" maxlength="200">{{ tags }}</textarea>
                 <br><label><small>Space separated. Use underscores for tags with spaces in them.</small></label>
             </div>
 
+            {% if is_initial_upload %}
             <div>
                 {% if force_reencode %}
                     <label for="reencode">Reencode <em>(required, <a href="{{ url_for('wiki.wiki_page',page='reencode') }}">learn more</a>)</em></label>
@@ -77,6 +78,7 @@
                      <br><small>This will ensure the sample is compatible with the website and will not cause errors.<br>You should only uncheck this if it's important the original sample's metadata remain intact.</small>
                 {% endif %}
             </div>
+            {% endif %}
 
             <div>
                 <button type="submit" class="submit_button">Save</button>
@@ -88,7 +90,7 @@
     <script>
     document.querySelector(".submit_button").onclick = function() {
         const reencode = document.getElementById('reencode');
-        if (reencode.checked) {
+        if (reencode && reencode.checked) {
             document.getElementById('changelog-popup').classList.remove('hidden');
             document.getElementById('changelog-background').classList.remove('hidden');
         }

--- a/templates/sample.html
+++ b/templates/sample.html
@@ -71,6 +71,10 @@
                         <span class="like-count">{{ sample.likes|length }}</span>
                     </a>
                     {% if current_user.is_admin or current_user.id == uploader.id %}
+                        <a href="{{ url_for('main.edit_sample', sample_id=sample.id) }}"
+                           class="sample-page-button" style="--hue: 40">
+                            <span>Edit sample</span>
+                        </a>
                         <a class="sample-page-button delete-button" data-sample-id="{{ sample.id }}" style="--hue: 0">
                             <span>Delete sample</span>
                         </a>

--- a/templates/sample.html
+++ b/templates/sample.html
@@ -14,7 +14,11 @@
 
 {% block content %}
     <div class="warning-box">
-
+        {% if not sample.is_public %}
+            <div class="privacy-warning">
+                <b>Note:</b> This sample is private and only visible to you. It will be made public once it has been reviewed by a moderator.
+            </div>
+        {% endif %}
     </div>
     <div class="sample-page-layout">
         <aside class="tag-sidebar">

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -13,7 +13,7 @@
     </div>
 
     <div class="upload-form">
-        {% if current_user is none %}
+        {% if not current_user.is_authenticated %}
             {% if require_user_approval %}
                 Only approved registered users can upload samples.
             {% else %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -2,9 +2,30 @@
 
 {% block content %}
 
+    {% if (current_user.is_admin or current_user.id == user.id) and samples_under_review %}
     <div class="home-samples-box">
         <div class="home-samples-header" style="display: flex; align-items: center; padding-bottom: 10px;">
-            <h1>All Samples by {{ user.username }}</h1>
+            <h1>Samples currently under review</h1>
+        </div>
+
+        <div class="home-samples-grid">
+            {% for sample in samples_under_review %}
+                <div class="home-sample">
+                    <a href="{{ url_for('main.sample_page',sample_id=sample.id) }}"><img
+                            src="{{ url_for('static', filename='media/thumbs/' + sample.thumbnail_filename) }}"
+                            alt="sample"></a>
+                    <a href="{{ url_for('main.sample_page',sample_id=sample.id) }}"><div>{{ sample.filename }}</div></a>
+                    <p class="upload-date" data-utc="{{ sample.upload_date.isoformat() }}"
+                       style="font-size: 14px;"></p>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="home-samples-box">
+        <div class="home-samples-header" style="display: flex; align-items: center; padding-bottom: 10px;">
+            <h1>Public Samples by {{ user.username }}</h1>
         </div>
 
         <div class="home-samples-grid">

--- a/utils.py
+++ b/utils.py
@@ -7,12 +7,12 @@ from sqlalchemy import create_engine, text
 from config import SQLALCHEMY_DATABASE_URI
 from models import Sample
 
-def add_sample_to_db(filename, stored_as, upload_date, thumbnail, uploader, source_id):
+def add_sample_to_db(filename, stored_as, upload_date, thumbnail, uploader, source_id, is_public):
     with engine.connect() as conn:
         try:
             sample = conn.execute(
                 text(
-                    "INSERT INTO sample (filename, stored_as, upload_date, thumbnail_filename, uploader, source_id) VALUES (:filename, :stored_as, :upload_date, :thumbnail_filename, :uploader, :source_id) RETURNING id"
+                    "INSERT INTO sample (filename, stored_as, upload_date, thumbnail_filename, uploader, source_id, is_public) VALUES (:filename, :stored_as, :upload_date, :thumbnail_filename, :uploader, :source_id, :is_public) RETURNING id"
                 ),
                 {
                     "filename": filename,
@@ -21,40 +21,12 @@ def add_sample_to_db(filename, stored_as, upload_date, thumbnail, uploader, sour
                     "thumbnail_filename": thumbnail,
                     "uploader": uploader,
                     "source_id": source_id,
+                    "is_public": is_public,
                 },
             )
             conn.commit()
-            try:
-                sample_id = sample.scalar()
-                metadata = get_metadata(sample_id)
-                for stream in metadata['streams']:
-                    if stream['codec_type'] == "video":
-                        video_stream = stream
-                        break
-                framerate = video_stream['r_frame_rate'].split('/')
-                framerate = int(framerate[0]) / int(framerate[1])
-                conn.execute(
-                    text(
-                        "INSERT INTO metadata (sample_id, filesize, width, height, aspect_ratio, framerate, codec) VALUES (:sample_id, :filesize, :width, :height, :aspect_ratio, :framerate, :codec)"
-                    ),
-                    {
-                        "sample_id": sample_id,
-                        "filesize": metadata['format']['size'],
-                        "width": video_stream['width'],
-                        "height": video_stream['height'],
-                        "aspect_ratio": video_stream['display_aspect_ratio'],
-                        "framerate": framerate,
-                        "codec": video_stream['codec_name'],
-                    },
-                )
-                conn.commit()
-            except Exception as e:
-                conn.execute(
-                    text("DELETE FROM sample WHERE id = :sample_id"),
-                    {"sample_id": sample_id},
-                )
-                conn.commit()
-                raise ValueError(f"Error adding metadata: {e}")
+            sample_id = sample.scalar()
+            return sample_id
         except Exception as e:
             print(f"Error adding sample: {e}")
             raise


### PR DESCRIPTION
Closes #34, closes #36

Optional features if I care enough before getting this in:
- [x] Allow for re-editing samples that have already been posted
- [x] Add section on user page for unreviewed samples (or some way for users to see their private samples)
- [x] #58 
- [ ] Add admin panel to approve or deny samples